### PR TITLE
Allow empty default_cmd in brn.conf

### DIFF
--- a/src/brp/Makefile
+++ b/src/brp/Makefile
@@ -1,5 +1,5 @@
-all: brp.c
-	$(CC) -Wall -static brp.c -o brp -lfuse -lbedrock
+all: brp.c parser.c
+	$(CC) -Wall -static brp.c parser.c -o brp -lfuse -lbedrock
 
 clean:
 	-rm brp

--- a/src/brp/brp.c
+++ b/src/brp/brp.c
@@ -601,7 +601,13 @@ int corresponding(char *in_path,
 	char tmp_path[PATH_MAX+1];
 	int *stratum_root_fd = malloc(sizeof(int)*nstratum);
 
-	int ret = chdir(STRATA_ROOT);
+	int ret = seteuid(0);
+	if (unlikely(ret < 0)) {
+		perror("seteuid");
+		exit(1);
+	}
+
+	ret = chdir(STRATA_ROOT);
 	if (unlikely(ret < 0)) {
 		// strata root missing?!
 		perror("Failed to chdir to strata root");
@@ -615,18 +621,12 @@ int corresponding(char *in_path,
 		if (unlikely(stratum_root_fd[st] < 0))
 			continue;
 
-		ret = seteuid(0);
-		if (unlikely(ret < 0))
-			return -errno;
-
 		ret = fchdir(stratum_root_fd[st]);
 		if (unlikely(ret < 0))
 			continue;
 		ret = chroot(".");
 		if (unlikely(ret < 0))
 			continue;
-
-		SET_CALLER_UID();
 
 		/* check for a match on something contained in one of the configured
 		 * directories */
@@ -648,6 +648,19 @@ int corresponding(char *in_path,
 				ret = stat(tmp_path, stbuf);
 				if (ret < 0)
 					continue;
+
+				// Check again with proper permission
+				SET_CALLER_UID();
+				ret = stat(tmp_path, stbuf);
+				if (unlikely(ret < 0)) {
+					ret = seteuid(0);
+					if (unlikely(ret < 0)) {
+						perror("seteuid");
+						exit(1);
+					}
+					continue;
+				}
+
 				*arg_out_item = &out_items[i];
 				*arg_in_item = &out_items[i].in_items[j];
 				*stratum_id = st;
@@ -677,6 +690,18 @@ int corresponding(char *in_path,
 				int ret = stat(in_item[j].path, stbuf);
 				if (ret < 0)
 					continue;
+
+				// Check again with proper permission
+				SET_CALLER_UID();
+				ret = stat(in_item[j].path, stbuf);
+				if (unlikely(ret < 0)) {
+					ret = seteuid(0);
+					if (unlikely(ret < 0)) {
+						perror("seteuid");
+						exit(1);
+					}
+					continue;
+				}
 				*arg_out_item = &out_items[i];
 				*arg_in_item = &out_items[i].in_items[j];
 				*stratum_id = st;

--- a/src/brp/brp.c
+++ b/src/brp/brp.c
@@ -303,7 +303,7 @@ void parse_config()
 			out_items[i].in_items[j].stratum = malloc((strlen(line)+1) * sizeof(char));
 			strcpy(out_items[i].in_items[j].stratum, line);
 			out_items[i].in_items[j].stratum_len = strlen(line);
-			
+
 			/* get stratum path */
 			fgets(line, maxlinelen, fp);
 			line[strlen(line)-1] = '\0'; /* strip newline */
@@ -762,10 +762,10 @@ int brp_stat(char *path, struct stat *stbuf)
 /*
  * Given an input path, finds the corresponding content to output (if any) and
  * populates various related fields (e.g. stat info) accordingly.
+ *
+ * Returns a file descriptor to the found file, -ENOENT indicates not found
  */
 int corresponding(char *in_path,
-		char* out_path,
-		size_t out_path_size,
 		struct stat *stbuf,
 		struct out_item **arg_out_item,
 		struct in_item **arg_in_item,
@@ -779,7 +779,7 @@ int corresponding(char *in_path,
 
 	size_t i, j;
 	size_t in_path_len = strlen(in_path);
-	char tmp_path[out_path_size+1];
+	char tmp_path[PATH_MAX+1], out_path[PATH_MAX+1];
 
 	/* check for a match on something contained in one of the configured
 	 * directories */
@@ -788,17 +788,20 @@ int corresponding(char *in_path,
 				in_path[out_items[i].path_len] == '/' &&
 				out_items[i].file_type == FILE_TYPE_DIRECTORY) {
 			for (j = 0; j < out_items[i].in_item_count; j++) {
-				strncpy(tmp_path, out_items[i].in_items[j].full_path, out_path_size);
-				strncat(tmp_path, in_path + out_items[i].path_len, out_path_size - out_items[i].in_items[j].full_path_len);
-				if (strlen(tmp_path) == out_path_size) {
+				strncpy(tmp_path, out_items[i].in_items[j].full_path, PATH_MAX);
+				strncat(tmp_path, in_path + out_items[i].path_len, PATH_MAX-out_items[i].in_items[j].full_path_len);
+				if (strlen(tmp_path) == PATH_MAX) {
 					/* would have buffer overflowed, treat as bad value */
 					continue;
 				}
-				if (brp_realpath(tmp_path, out_path, out_path_size) >= 0 && lstat(out_path, stbuf) >= 0) {
+				if (brp_realpath(tmp_path, out_path, PATH_MAX) >= 0 && lstat(out_path, stbuf) >= 0) {
 					*arg_out_item = &out_items[i];
 					*arg_in_item = &out_items[i].in_items[j];
 					*tail = in_path + out_items[i].path_len;
-					return 0;
+					if (S_ISDIR(stbuf->st_mode))
+						return open(out_path, O_RDONLY | O_DIRECTORY);
+					else
+						return open(out_path, O_RDONLY);
 				}
 			}
 		}
@@ -811,16 +814,19 @@ int corresponding(char *in_path,
 		if (strncmp(out_items[i].path, in_path, in_path_len) == 0 &&
 				(out_items[i].path[in_path_len] == '\0')) {
 			for (j = 0; j < out_items[i].in_item_count; j++) {
-				if (brp_realpath(out_items[i].in_items[j].full_path, out_path, out_path_size) >=0) {
-					if (out_items[i].file_type == FILE_TYPE_DIRECTORY) {
-						memcpy(stbuf, &parent_stat, sizeof(parent_stat));
-					} else {
-						lstat(out_path, stbuf);
-					}
+				if (brp_realpath(out_items[i].in_items[j].full_path, out_path, PATH_MAX) >=0) {
+					int fd = -1;
 					*arg_out_item = &out_items[i];
 					*arg_in_item = &out_items[i].in_items[j];
 					*tail = "";
-					return 0;
+					if (out_items[i].file_type == FILE_TYPE_DIRECTORY) {
+						memcpy(stbuf, &parent_stat, sizeof(parent_stat));
+						fd = open(out_path, O_RDONLY | O_DIRECTORY);
+					} else {
+						lstat(out_path, stbuf);
+						fd = open(out_path, O_RDONLY);
+					}
+					return fd;
 				}
 			}
 		}
@@ -834,13 +840,18 @@ int corresponding(char *in_path,
 		if (strncmp(out_items[i].path, in_path, in_path_len) == 0 &&
 				(out_items[i].path[in_path_len] == '/')) {
 			for (j = 0; j < out_items[i].in_item_count; j++) {
-				if (brp_realpath(out_items[i].in_items[j].full_path, out_path, out_path_size) >=0 &&
+				if (brp_realpath(out_items[i].in_items[j].full_path, out_path, PATH_MAX) >=0 &&
 						lstat(out_path, stbuf) >= 0) {
-					memcpy(stbuf, &parent_stat, sizeof(parent_stat));
+					int fd;
 					*arg_out_item = &out_items[i];
 					*arg_in_item = &out_items[i].in_items[j];
 					*tail = "";
-					return 0;
+					if (S_ISDIR(stbuf->st_mode))
+						fd = open(out_path, O_RDONLY | O_DIRECTORY);
+					else
+						fd = open(out_path, O_RDONLY);
+					memcpy(stbuf, &parent_stat, sizeof(parent_stat));
+					return fd;
 				}
 			}
 		}
@@ -853,7 +864,7 @@ int corresponding(char *in_path,
  * Apply relevant filter to getattr output.
  */
 void stat_filter(struct stat *stbuf,
-		const char const *in_path,
+		int in_fd,
 		int filter,
 		struct in_item *item,
 		const char *tail)
@@ -868,6 +879,7 @@ void stat_filter(struct stat *stbuf,
 
 	if (S_ISDIR(stbuf->st_mode)) {
 		/* filters below only touch files */
+		close(in_fd);
 		return;
 	}
 
@@ -889,7 +901,7 @@ void stat_filter(struct stat *stbuf,
 		break;
 
 	case FILTER_EXEC:
-		fp = fopen(in_path, "r");
+		fp = fdopen(in_fd, "r");
 		if (fp != NULL) {
 			while (fgets(line, PATH_MAX, fp) != NULL) {
 				if (strncmp(line, "Exec=", strlen("Exec=")) == 0 ||
@@ -907,12 +919,13 @@ void stat_filter(struct stat *stbuf,
 		break;
 
 	}
+	close(in_fd);
 }
 
 /*
  * Do read() and apply relevant filter.
  */
-int read_filter(const char *in_path,
+int read_filter(int in_fd,
 		int filter,
 		struct in_item *item,
 		const char *tail,
@@ -921,8 +934,8 @@ int read_filter(const char *in_path,
 		off_t offset)
 {
 	char *execs[] = {"TryExec=", "ExecStart=", "ExecStop=", "ExecReload=", "Exec="};
-	size_t exec_cnt = sizeof(execs) / sizeof(execs[0]);
-	int fd, ret;
+	size_t exec_cnt = sizeof(execs) / sizeof(execs[0]), left_to_skip, written;
+	int ret;
 	const size_t line_max = PATH_MAX;
 	char line[line_max+1];
 	FILE *fp;
@@ -930,64 +943,54 @@ int read_filter(const char *in_path,
 	switch (filter) {
 
 	case FILTER_PASS:
-		if ((fd = open(in_path, O_RDONLY)) >= 0) {
-			ret = pread(fd, buf, size, offset);
-			close(fd);
-			return ret;
-		}
-		return fd;
-		break;
+		ret = pread(in_fd, buf, size, offset);
+		close(in_fd);
+		return ret;
 
 	case FILTER_BRC_WRAP:
-		if (access(in_path, F_OK) == 0) {
-			size_t left_to_skip = offset;
-			size_t written = 0;
-			strcatoffset(buf, "#!/bedrock/libexec/busybox sh\nexec /bedrock/bin/brc ", &left_to_skip, &written, size);
-			strcatoffset(buf, item->stratum, &left_to_skip, &written, size);
-			strcatoffset(buf, " ", &left_to_skip, &written, size);
-			strcatoffset(buf, item->stratum_path, &left_to_skip, &written, size);
-			strcatoffset(buf, tail, &left_to_skip, &written, size);
-			strcatoffset(buf, " \"$@\"\n", &left_to_skip, &written, size);
-			return written;
-		} else {
-			return -EPERM;
-		}
-		break;
+		close(in_fd);
+
+		left_to_skip = offset;
+		written = 0;
+		strcatoffset(buf, "#!/bedrock/libexec/busybox sh\nexec /bedrock/bin/brc ", &left_to_skip, &written, size);
+		strcatoffset(buf, item->stratum, &left_to_skip, &written, size);
+		strcatoffset(buf, " ", &left_to_skip, &written, size);
+		strcatoffset(buf, item->stratum_path, &left_to_skip, &written, size);
+		strcatoffset(buf, tail, &left_to_skip, &written, size);
+		strcatoffset(buf, " \"$@\"\n", &left_to_skip, &written, size);
+		return written;
 
 	case FILTER_EXEC:
-		if (access(in_path, F_OK) == 0) {
-			size_t left_to_skip = offset;
-			size_t written = 0;
-			fp = fopen(in_path, "r");
-			if (!fp) {
-				return -errno;
-			}
-			while (fgets(line, line_max, fp) != NULL) {
-				size_t i;
-				int found = 0;
-				for (i = 0; i < exec_cnt; i++) {
-					if (strncmp(line, execs[i], strlen(execs[i])) == 0) {
-						found = 1;
-						strcatoffset(buf, execs[i], &left_to_skip, &written, size);
-						strcatoffset(buf, "/bedrock/bin/brc ", &left_to_skip, &written, size);
-						strcatoffset(buf, item->stratum, &left_to_skip, &written, size);
-						strcatoffset(buf, " ", &left_to_skip, &written, size);
-						strcatoffset(buf, line + strlen(execs[i]), &left_to_skip, &written, size);
-					}
-				}
-				if (!found) {
-					strcatoffset(buf, line, &left_to_skip, &written, size);
-				}
-				if (written >= size) {
-					break;
-				}
-			}
-			fclose(fp);
-			return written;
-		} else {
-			return -EPERM;
+		left_to_skip = offset;
+		written = 0;
+		fp = fdopen(in_fd, "r");
+		if (!fp) {
+			int ret = errno;
+			close(in_fd);
+			return -ret;
 		}
-		break;
+		while (fgets(line, line_max, fp) != NULL) {
+			size_t i;
+			int found = 0;
+			for (i = 0; i < exec_cnt; i++) {
+				if (strncmp(line, execs[i], strlen(execs[i])) == 0) {
+					found = 1;
+					strcatoffset(buf, execs[i], &left_to_skip, &written, size);
+					strcatoffset(buf, "/bedrock/bin/brc ", &left_to_skip, &written, size);
+					strcatoffset(buf, item->stratum, &left_to_skip, &written, size);
+					strcatoffset(buf, " ", &left_to_skip, &written, size);
+					strcatoffset(buf, line + strlen(execs[i]), &left_to_skip, &written, size);
+				}
+			}
+			if (!found) {
+				strcatoffset(buf, line, &left_to_skip, &written, size);
+			}
+			if (written >= size) {
+				break;
+			}
+		}
+		fclose(fp);
+		return written;
 	}
 
 	return -ENOENT;
@@ -1007,7 +1010,6 @@ static int brp_getattr(const char const *in_path, struct stat *stbuf)
 {
 	SET_CALLER_UID();
 
-	char out_path[PATH_MAX+1];
 	struct out_item *out_item;
 	struct in_item *in_item;
 	char *tail;
@@ -1031,8 +1033,8 @@ static int brp_getattr(const char const *in_path, struct stat *stbuf)
 		}
 	}
 
-	if ( (ret = corresponding((char*)in_path, out_path, PATH_MAX, stbuf, &out_item, &in_item, &tail)) >= 0) {
-		stat_filter(stbuf, out_path, out_item->filter, in_item, tail);
+	if ( (ret = corresponding((char*)in_path, stbuf, &out_item, &in_item, &tail)) >= 0) {
+		stat_filter(stbuf, ret, out_item->filter, in_item, tail);
 		return 0;
 	} else {
 		return ret;
@@ -1082,9 +1084,9 @@ static int brp_readdir(const char *in_path, void *buf, fuse_fill_dir_t filler, o
 					/* would have buffer overflowed, treat as bad value */
 					continue;
 				}
-				if (brp_stat(out_path, &stbuf) < 0) {
+				if (brp_stat(out_path, &stbuf) < 0)
 					continue;
-				}
+
 				if (S_ISDIR(stbuf.st_mode)) {
 					if (! (d = opendir(out_path)) ) {
 						continue;
@@ -1151,7 +1153,6 @@ static int brp_open(const char *in_path, struct fuse_file_info *fi)
 {
 	SET_CALLER_UID();
 
-	char out_path[PATH_MAX+1];
 	struct out_item *out_item;
 	struct in_item *in_item;
 	char *tail;
@@ -1185,7 +1186,8 @@ static int brp_open(const char *in_path, struct fuse_file_info *fi)
 		return -EACCES;
 	}
 
-	if ( (ret = corresponding((char*)in_path, out_path, PATH_MAX, &stbuf, &out_item, &in_item, &tail)) >= 0) {
+	if ( (ret = corresponding((char*)in_path, &stbuf, &out_item, &in_item, &tail)) >= 0) {
+		close(ret);
 		return 0;
 	}
 	return -ENOENT;
@@ -1198,7 +1200,6 @@ static int brp_read(const char *in_path, char *buf, size_t size, off_t offset, s
 {
 	SET_CALLER_UID();
 
-	char out_path[PATH_MAX+1];
 	struct out_item *out_item;
 	struct in_item *in_item;
 	char *tail;
@@ -1217,12 +1218,12 @@ static int brp_read(const char *in_path, char *buf, size_t size, off_t offset, s
 		return ret;
 	}
 
-	ret = corresponding((char*) in_path, out_path, PATH_MAX, &stbuf, &out_item, &in_item, &tail);
+	ret = corresponding((char*) in_path, &stbuf, &out_item, &in_item, &tail);
 	if (ret < 0) {
 		return ret;
 	}
 
-	return read_filter(out_path, out_item->filter, in_item, tail, buf, size, offset);
+	return read_filter(ret, out_item->filter, in_item, tail, buf, size, offset);
 }
 
 /*

--- a/src/brp/brp.c
+++ b/src/brp/brp.c
@@ -720,24 +720,24 @@ int corresponding(char *in_path,
 	char stratum_prefix[PATH_MAX+1], tmp_path[PATH_MAX+1];
 	strcpy(stratum_prefix, STRATA_ROOT);
 
-	/* check for a match on something contained in one of the configured
-	 * directories */
-	for (i = 0; i < out_item_count; i++) {
-		if (strncmp(in_path, out_items[i].path, out_items[i].path_len) ||
-		    in_path[out_items[i].path_len] != '/' ||
-		    out_items[i].file_type != FILE_TYPE_DIRECTORY)
+	for (st = 0; st < nstratum; st++) {
+		if (unlikely(STRATA_ROOT_LEN+stratum_len[st] > PATH_MAX))
 			continue;
-		struct in_item *in_item = out_items[i].in_items;
-		for (j = 0; j < out_items[i].in_item_count; j++) {
-			if (unlikely(in_item[j].path_len+in_path_len-out_items[i].path_len > PATH_MAX))
+		stratum_prefix[STRATA_ROOT_LEN] = '\0';
+		strcat(stratum_prefix, stratum[st]);
+		/* check for a match on something contained in one of the configured
+		 * directories */
+		for (i = 0; i < out_item_count; i++) {
+			if (strncmp(in_path, out_items[i].path, out_items[i].path_len) ||
+			    in_path[out_items[i].path_len] != '/' ||
+			    out_items[i].file_type != FILE_TYPE_DIRECTORY)
 				continue;
-			strcpy(tmp_path, in_item[j].path);
-			strcat(tmp_path, in_path+out_items[i].path_len);
-			for (st = 0; st < nstratum; st++) {
-				if (unlikely(STRATA_ROOT_LEN+stratum_len[st] > PATH_MAX))
+			struct in_item *in_item = out_items[i].in_items;
+			for (j = 0; j < out_items[i].in_item_count; j++) {
+				if (unlikely(in_item[j].path_len+in_path_len-out_items[i].path_len > PATH_MAX))
 					continue;
-				stratum_prefix[STRATA_ROOT_LEN] = '\0';
-				strcat(stratum_prefix, stratum[st]);
+				strcpy(tmp_path, in_item[j].path);
+				strcat(tmp_path, in_path+out_items[i].path_len);
 
 				fd = brp_openplus(tmp_path, stratum_prefix, stbuf);
 				if (fd >= 0) {
@@ -749,24 +749,18 @@ int corresponding(char *in_path,
 				}
 			}
 		}
-	}
 
-	/*
-	 * Check for a match on a virtual parent directory of a configured
-	 * item.
-	 */
-	for (i = 0; i < out_item_count; i++) {
-		if (strncmp(out_items[i].path, in_path, in_path_len) ||
-		    (out_items[i].path[in_path_len] != '/' && out_items[i].path[in_path_len] != '\0'))
-			continue;
+		/*
+		 * Check for a match on a virtual parent directory of a configured
+		 * item.
+		 */
+		for (i = 0; i < out_item_count; i++) {
+			if (strncmp(out_items[i].path, in_path, in_path_len) ||
+			    (out_items[i].path[in_path_len] != '/' && out_items[i].path[in_path_len] != '\0'))
+				continue;
 
-		struct in_item *in_item = out_items[i].in_items;
-		for (j = 0; j < out_items[i].in_item_count; j++) {
-			for (st = 0; st < nstratum; st++) {
-				if (unlikely(STRATA_ROOT_LEN+stratum_len[st] > PATH_MAX))
-					continue;
-				stratum_prefix[STRATA_ROOT_LEN] = '\0';
-				strcat(stratum_prefix, stratum[st]);
+			struct in_item *in_item = out_items[i].in_items;
+			for (j = 0; j < out_items[i].in_item_count; j++) {
 				fd = brp_openplus(in_item[j].path, stratum_prefix, stbuf);
 				if (fd >= 0) {
 					*arg_out_item = &out_items[i];
@@ -999,29 +993,29 @@ static int brp_readdir(const char *in_path, void *buf, fuse_fill_dir_t filler, o
 
 	strcpy(stratum_prefix, STRATA_ROOT);
 
-	for (i = 0; i < out_item_count; i++) {
-		/*
-		 * Check for contents of one of the configured directories
-		 */
-		in_item = out_items[i].in_items;
-		if (strncmp(in_path, out_items[i].path, out_items[i].path_len) ||
-		    (in_path[out_items[i].path_len] != '\0' &&
-		     in_path[out_items[i].path_len]  != '/') ||
-		    out_items[i].file_type != FILE_TYPE_DIRECTORY)
+	for (st = 0; st < nstratum; st++) {
+		if (unlikely(STRATA_ROOT_LEN+stratum_len[st] > PATH_MAX))
 			continue;
-		for (j = 0; j < out_items[i].in_item_count; j++) {
-			for (st = 0; st < nstratum; st++) {
+		stratum_prefix[STRATA_ROOT_LEN] = '\0';
+		strcat(stratum_prefix, stratum[st]);
+		for (i = 0; i < out_item_count; i++) {
+			/*
+			 * Check for contents of one of the configured directories
+			 */
+			in_item = out_items[i].in_items;
+			if (strncmp(in_path, out_items[i].path, out_items[i].path_len) ||
+			    (in_path[out_items[i].path_len] != '\0' &&
+			     in_path[out_items[i].path_len]  != '/') ||
+			    out_items[i].file_type != FILE_TYPE_DIRECTORY)
+				continue;
+			for (j = 0; j < out_items[i].in_item_count; j++) {
 				if (in_item[j].path_len+
 				    in_path_len-out_items[i].path_len > PATH_MAX)
-					continue;
-				if (STRATA_ROOT_LEN+stratum_len[st] > PATH_MAX)
 					continue;
 
 				strcpy(out_path, in_item[j].path);
 				strcat(out_path, in_path+out_items[i].path_len);
 
-				stratum_prefix[STRATA_ROOT_LEN] = '\0';
-				strcat(stratum_prefix, stratum[st]);
 
 				int fd = brp_openplus(out_path, stratum_prefix, &stbuf);
 				if (fd < 0)
@@ -1045,23 +1039,16 @@ static int brp_readdir(const char *in_path, void *buf, fuse_fill_dir_t filler, o
 				}
 			}
 		}
-	}
-	for (i = 0; i < out_item_count; i++) {
-		/*
-		 * Check for a match directly on one of the configured items or a virtual parent directory
-		 */
-		if (strncmp(out_items[i].path, in_path, in_path_len) ||
-		    out_items[i].path[in_path_len] != '/')
-			continue;
+		for (i = 0; i < out_item_count; i++) {
+			/*
+			 * Check for a match directly on one of the configured items or a virtual parent directory
+			 */
+			if (strncmp(out_items[i].path, in_path, in_path_len) ||
+			    out_items[i].path[in_path_len] != '/')
+				continue;
 
-		in_item = out_items[i].in_items;
-		for (j = 0; j < out_items[i].in_item_count; j++) {
-			for (st = 0; st < nstratum; st++) {
-				if (STRATA_ROOT_LEN+stratum_len[st] > PATH_MAX)
-					continue;
-				stratum_prefix[STRATA_ROOT_LEN] = '\0';
-				strcat(stratum_prefix, stratum[st]);
-
+			in_item = out_items[i].in_items;
+			for (j = 0; j < out_items[i].in_item_count; j++) {
 				int fd = brp_openplus(in_item[j].path, stratum_prefix, &stbuf);
 				if (fd > 0) {
 					close(fd);

--- a/src/brp/brp.c
+++ b/src/brp/brp.c
@@ -569,139 +569,18 @@ int write_attempt(const char* path)
 	}
 }
 
-/*
- * Open and stat a file in a strata, treating absolute symlinks as symlinks
- * relative to the strata's root. @path must be an absolute path.
- *
- * Returns the file descriptor on success, <0 on failure.  If there is no resulting
- * file/directory it is considered an error (unlike, for example, readlink(2)).
- *
- * This is used over something like realpath() due to the need to have absolute
- * symlinks start at the symlink's stratum's root.  e.g. if a symlink at
- * "/bedrock/strata/foo/bar" symlinks to "/qux" that should be treated as
- * "/bedrock/strata/foo/qux".
- */
-int brp_openplus(char *path, char *stratum_prefix, struct stat *stbuf)
-{
-	char *slash;
-	const int LOOP_MAX = 20;
-	int end = 0;
-	int loop = 0;
-	ssize_t readlink_len;
-	size_t stratum_prefix_len, path_fragment_len, current_path_len;
-
-	char current_path[PATH_MAX+1];
-	char link_path[PATH_MAX+1];
-	char path_fragment[PATH_MAX+1];
-
-	if (path[0] != '/')
-		return -1;
-
-	slash = path+1;
-	while(*slash == '/')
-		slash++;
-
-	stratum_prefix_len = strlen(stratum_prefix);
-
-	if (stratum_prefix_len+1 > PATH_MAX)
-		return -1;
-
-	/*
-	 * Copy the path components after 'stratum_prefix/'
-	 */
-	strcpy(current_path, slash);
-	strcpy(path_fragment, stratum_prefix);
-	strcat(path_fragment, "/");
-	path_fragment_len = stratum_prefix_len+1;
-	current_path_len = strlen(current_path);
-	slash = current_path;
-
-	/*
-	 * Loop over every directory in a given file path, e.g. in
-	 * "/foo/bar/baz/" loop over "/foo" then "/foo/bar" then
-	 * "/foo/bar/baz", starting with the stratum_prefix.  If any directory
-	 * is found to be a symlink, resolve symlink then start over.
-	 */
-	while (1) {
-		/* find next file/directory in file path */
-		int ret;
-		char *next_slash = strchr(slash, '/');
-		size_t left_len, last_path_fragment_len = path_fragment_len;
-
-		/* on final item in file path, the file itself */
-		if (next_slash == NULL) {
-			end = 1;
-			strcpy(path_fragment+path_fragment_len, slash);
-			path_fragment_len += strlen(slash);
-			left_len = 0;
-		} else {
-			strncpy(path_fragment+path_fragment_len, slash, next_slash-slash+1);
-			path_fragment_len += next_slash-slash+1;
-			path_fragment[path_fragment_len] = '\0';
-			left_len = current_path_len-(next_slash-current_path);
-		}
-
-		ret = lstat(path_fragment, stbuf);
-		if (ret != 0)
-			return ret;
-
-		if (!S_ISLNK(stbuf->st_mode) && !end) {
-			slash = next_slash+1;
-			continue;
-		}
-		if (!S_ISLNK(stbuf->st_mode) && end) {
-			return S_ISDIR(stbuf->st_mode) ?
-			    open(path_fragment, O_RDONLY|O_DIRECTORY) :
-			    open(path_fragment, O_RDONLY);
-		}
-		if (S_ISLNK(stbuf->st_mode)) {
-			if ((readlink_len = readlink(path_fragment, link_path, PATH_MAX)) < 0) {
-				return -errno;
-			}
-			link_path[readlink_len] = '\0';
-			if (link_path[0] == '/') {
-				/* absolute symlink */
-				current_path_len = readlink_len-1+left_len;
-
-				if (current_path_len > PATH_MAX)
-					return -ENAMETOOLONG;
-
-				/* replace the current component of current_path with link_path */
-				memmove(current_path+readlink_len-1, next_slash, left_len);
-				strncpy(current_path, link_path+1, readlink_len-1);
-				path_fragment_len = stratum_prefix_len+1;
-
-				slash = current_path;
-			} else {
-				/* relative symlink */
-				current_path_len = (slash-current_path)+readlink_len+left_len;
-
-				if (current_path_len > PATH_MAX)
-					return -ENAMETOOLONG;
-
-				/* replace the current component of current_path with link_path */
-				memmove(slash+strlen(link_path), next_slash, left_len);
-				strncpy(slash, link_path, readlink_len);
-
-				/* go back one component */
-				path_fragment_len = last_path_fragment_len;
-			}
-			end = 0;
-			current_path[current_path_len] = '\0';
-			if ((loop++) >= LOOP_MAX) {
-				return -ELOOP;
-			}
-		}
-	}
-}
+static int brp_orig_cwd, brp_orig_root;
 
 /*
  * Given an input path, finds the corresponding content to output (if any) and
  * populates various related fields (e.g. stat info) accordingly.
  *
- * Returns a file descriptor to the found file, -ENOENT indicates not found
+ * Returns 0 if found, -ENOENT indicates not found
+ *
+ * If out_fd is not NULL, the file will be opened, and file descriptor assigned.
  */
 int corresponding(char *in_path,
+		int *out_fd,
 		struct stat *stbuf,
 		struct out_item **arg_out_item,
 		int *stratum_id,
@@ -714,17 +593,41 @@ int corresponding(char *in_path,
 		return 0;
 	}
 
+	int retval = -ENOENT;
+
 	size_t i, j;
 	size_t in_path_len = strlen(in_path);
-	int fd, st;
-	char stratum_prefix[PATH_MAX+1], tmp_path[PATH_MAX+1];
-	strcpy(stratum_prefix, STRATA_ROOT);
+	int st;
+	char tmp_path[PATH_MAX+1];
+	int *stratum_root_fd = malloc(sizeof(int)*nstratum);
+
+	int ret = chdir(STRATA_ROOT);
+	if (unlikely(ret < 0)) {
+		// strata root missing?!
+		perror("Failed to chdir to strata root");
+		exit(1);
+	}
+
+	for (st = 0; st < nstratum; st++)
+		stratum_root_fd[st] = open(stratum[st], O_RDONLY|O_DIRECTORY);
 
 	for (st = 0; st < nstratum; st++) {
-		if (unlikely(STRATA_ROOT_LEN+stratum_len[st] > PATH_MAX))
+		if (unlikely(stratum_root_fd[st] < 0))
 			continue;
-		stratum_prefix[STRATA_ROOT_LEN] = '\0';
-		strcat(stratum_prefix, stratum[st]);
+
+		ret = seteuid(0);
+		if (unlikely(ret < 0))
+			return -errno;
+
+		ret = fchdir(stratum_root_fd[st]);
+		if (unlikely(ret < 0))
+			continue;
+		ret = chroot(".");
+		if (unlikely(ret < 0))
+			continue;
+
+		SET_CALLER_UID();
+
 		/* check for a match on something contained in one of the configured
 		 * directories */
 		for (i = 0; i < out_item_count; i++) {
@@ -734,19 +637,26 @@ int corresponding(char *in_path,
 				continue;
 			struct in_item *in_item = out_items[i].in_items;
 			for (j = 0; j < out_items[i].in_item_count; j++) {
+				if (in_item[j].stratum_id >= 0 && in_item[j].stratum_id != st)
+					continue;
+
 				if (unlikely(in_item[j].path_len+in_path_len-out_items[i].path_len > PATH_MAX))
 					continue;
 				strcpy(tmp_path, in_item[j].path);
 				strcat(tmp_path, in_path+out_items[i].path_len);
 
-				fd = brp_openplus(tmp_path, stratum_prefix, stbuf);
-				if (fd >= 0) {
-					*arg_out_item = &out_items[i];
-					*arg_in_item = &out_items[i].in_items[j];
-					*stratum_id = st;
-					*tail = in_path + out_items[i].path_len;
-					return fd;
-				}
+				ret = stat(tmp_path, stbuf);
+				if (ret < 0)
+					continue;
+				*arg_out_item = &out_items[i];
+				*arg_in_item = &out_items[i].in_items[j];
+				*stratum_id = st;
+				*tail = in_path + out_items[i].path_len;
+
+				if (out_fd)
+					*out_fd = open(tmp_path, O_RDONLY);
+				retval = 0;
+				goto end;
 			}
 		}
 
@@ -761,22 +671,60 @@ int corresponding(char *in_path,
 
 			struct in_item *in_item = out_items[i].in_items;
 			for (j = 0; j < out_items[i].in_item_count; j++) {
-				fd = brp_openplus(in_item[j].path, stratum_prefix, stbuf);
-				if (fd >= 0) {
-					*arg_out_item = &out_items[i];
-					*arg_in_item = &out_items[i].in_items[j];
-					*stratum_id = st;
-					*tail = "";
-					if (out_items[i].path[in_path_len] == '/' ||
-							out_items[i].file_type == FILE_TYPE_DIRECTORY)
-						memcpy(stbuf, &parent_stat, sizeof(parent_stat));
-					return fd;
-				}
+				if (in_item[j].stratum_id >= 0 && in_item[j].stratum_id != st)
+					continue;
+
+				int ret = stat(in_item[j].path, stbuf);
+				if (ret < 0)
+					continue;
+				*arg_out_item = &out_items[i];
+				*arg_in_item = &out_items[i].in_items[j];
+				*stratum_id = st;
+				*tail = "";
+				if (out_items[i].path[in_path_len] == '/' ||
+				    out_items[i].file_type == FILE_TYPE_DIRECTORY)
+					memcpy(stbuf, &parent_stat, sizeof(parent_stat));
+				if (out_fd)
+					*out_fd = open(tmp_path, O_RDONLY);
+				retval = 0;
+				goto end;
 			}
 		}
 	}
 
-	return -ENOENT;
+end:
+	for (st = 0; st < nstratum; st++)
+		if (stratum_root_fd[st] > 0)
+			close(stratum_root_fd[st]);
+
+	free(stratum_root_fd);
+
+	// If anything goes wrong here, we are stuck in a different root.
+	// In that case we give up and quit.
+	ret = seteuid(0);
+	if (unlikely(ret < 0)) {
+		perror("seteuid");
+		exit(1);
+	}
+	ret = fchdir(brp_orig_root);
+	if (unlikely(ret < 0)) {
+		perror("Failed to chdir to original root");
+		exit(1);
+	}
+
+	ret = chroot(".");
+	if (unlikely(ret < 0)) {
+		perror("Failed to chroot to original root");
+		exit(1);
+	}
+
+	ret = fchdir(brp_orig_cwd);
+	if (unlikely(ret < 0)) {
+		perror("Failed to change back to old cwd");
+		exit(1);
+	}
+
+	return retval;
 }
 
 /*
@@ -935,7 +883,7 @@ static int brp_getattr(const char *in_path, struct stat *stbuf)
 	struct in_item *in_item;
 	char *tail;
 	char *config_str;
-	int ret;
+	int ret, fd;
 	int stratum_id;
 
 	if (in_path[0] == '/' && in_path[1] == '\0') {
@@ -955,8 +903,8 @@ static int brp_getattr(const char *in_path, struct stat *stbuf)
 		}
 	}
 
-	if ( (ret = corresponding((char*)in_path, stbuf, &out_item, &stratum_id, &in_item, &tail)) >= 0) {
-		stat_filter(stbuf, ret, out_item->filter, stratum_id, in_item, tail);
+	if ( (ret = corresponding((char*)in_path, &fd, stbuf, &out_item, &stratum_id, &in_item, &tail)) >= 0) {
+		stat_filter(stbuf, fd, out_item->filter, stratum_id, in_item, tail);
 		return 0;
 	} else {
 		return ret;
@@ -973,7 +921,7 @@ static int brp_readdir(const char *in_path, void *buf, fuse_fill_dir_t filler, o
 	(void) offset;
 	(void) fi;
 
-	char stratum_prefix[PATH_MAX+1], out_path[PATH_MAX+1];
+	char out_path[PATH_MAX+1];
 	size_t i, j;
 	int st;
 	size_t in_path_len = strlen(in_path);
@@ -985,19 +933,39 @@ static int brp_readdir(const char *in_path, void *buf, fuse_fill_dir_t filler, o
 	struct in_item *in_item;
 	int ret_val = -ENOENT;
 	char *slash;
+	int *stratum_root_fd = malloc(sizeof(int)*nstratum);
+
+	int ret = chdir(STRATA_ROOT);
+	if (unlikely(ret < 0)) {
+		// strata root missing?!
+		perror("Failed to chdir to strata root");
+		exit(1);
+	}
+
+	for (st = 0; st < nstratum; st++)
+		stratum_root_fd[st] = open(stratum[st], O_RDONLY|O_DIRECTORY);
 
 	struct dirent *dir;
 
 	struct str_vec v;
 	str_vec_new(&v);
 
-	strcpy(stratum_prefix, STRATA_ROOT);
-
 	for (st = 0; st < nstratum; st++) {
-		if (unlikely(STRATA_ROOT_LEN+stratum_len[st] > PATH_MAX))
+		if (unlikely(stratum_root_fd[st] < 0))
 			continue;
-		stratum_prefix[STRATA_ROOT_LEN] = '\0';
-		strcat(stratum_prefix, stratum[st]);
+
+		ret = seteuid(0);
+		if (unlikely(ret < 0))
+			return -errno;
+
+		ret = fchdir(stratum_root_fd[st]);
+		if (unlikely(ret < 0))
+			continue;
+		ret = chroot(".");
+		if (unlikely(ret < 0))
+			continue;
+
+		SET_CALLER_UID();
 		for (i = 0; i < out_item_count; i++) {
 			/*
 			 * Check for contents of one of the configured directories
@@ -1009,6 +977,9 @@ static int brp_readdir(const char *in_path, void *buf, fuse_fill_dir_t filler, o
 			    out_items[i].file_type != FILE_TYPE_DIRECTORY)
 				continue;
 			for (j = 0; j < out_items[i].in_item_count; j++) {
+				if (in_item[j].stratum_id >= 0 && in_item[j].stratum_id != st)
+					continue;
+
 				if (in_item[j].path_len+
 				    in_path_len-out_items[i].path_len > PATH_MAX)
 					continue;
@@ -1016,15 +987,15 @@ static int brp_readdir(const char *in_path, void *buf, fuse_fill_dir_t filler, o
 				strcpy(out_path, in_item[j].path);
 				strcat(out_path, in_path+out_items[i].path_len);
 
-
-				int fd = brp_openplus(out_path, stratum_prefix, &stbuf);
-				if (fd < 0)
+				ret = stat(out_path, &stbuf);
+				if (ret < 0)
 					continue;
 
 				if (S_ISDIR(stbuf.st_mode)) {
-					DIR *d = fdopendir(fd);
+					DIR *d = opendir(out_path);
 					if (!d) {
-						perror("fdopendir()");
+						perror("opendir()");
+						continue;
 					}
 					while ( (dir = readdir(d)) ) {
 						str_vec_append(&v, dir->d_name);
@@ -1049,19 +1020,20 @@ static int brp_readdir(const char *in_path, void *buf, fuse_fill_dir_t filler, o
 
 			in_item = out_items[i].in_items;
 			for (j = 0; j < out_items[i].in_item_count; j++) {
-				int fd = brp_openplus(in_item[j].path, stratum_prefix, &stbuf);
-				if (fd > 0) {
-					close(fd);
+				if (in_item[j].stratum_id >= 0 && in_item[j].stratum_id != st)
+					continue;
 
-					if (out_items[i].path_len-in_path_len-1 > PATH_MAX)
-						continue;
-					strcpy(out_path, out_items[i].path+in_path_len+1);
-					if ( (slash = strchr(out_path, '/')) ) {
-						*slash = '\0';
-					}
-					str_vec_append(&v, out_path);
-					break;
+				ret = stat(in_item[j].path, &stbuf);
+				if (ret < 0)
+					continue;
+				if (out_items[i].path_len-in_path_len-1 > PATH_MAX)
+					continue;
+				strcpy(out_path, out_items[i].path+in_path_len+1);
+				if ( (slash = strchr(out_path, '/')) ) {
+					*slash = '\0';
 				}
+				str_vec_append(&v, out_path);
+				break;
 			}
 		}
 	}
@@ -1082,6 +1054,37 @@ static int brp_readdir(const char *in_path, void *buf, fuse_fill_dir_t filler, o
 	}
 
 	str_vec_free(&v);
+
+	for (st = 0; st < nstratum; st++)
+		if (stratum_root_fd[st] >= 0)
+			close(stratum_root_fd[st]);
+
+	free(stratum_root_fd);
+
+	// If anything goes wrong here, we are stuck in a different root.
+	// In that case we give up and quit.
+	ret = seteuid(0);
+	if (unlikely(ret < 0)) {
+		perror("seteuid");
+		exit(1);
+	}
+	ret = fchdir(brp_orig_root);
+	if (unlikely(ret < 0)) {
+		perror("Failed to chdir to original root");
+		exit(1);
+	}
+
+	ret = chroot(".");
+	if (unlikely(ret < 0)) {
+		perror("Failed to chroot to original root");
+		exit(1);
+	}
+
+	ret = fchdir(brp_orig_cwd);
+	if (unlikely(ret < 0)) {
+		perror("Failed to change back to old cwd");
+		exit(1);
+	}
 
 	return ret_val;
 }
@@ -1127,8 +1130,7 @@ static int brp_open(const char *in_path, struct fuse_file_info *fi)
 		return -EACCES;
 	}
 
-	if ( (ret = corresponding((char*)in_path, &stbuf, &out_item, &stratum_id, &in_item, &tail)) >= 0) {
-		close(ret);
+	if ( (ret = corresponding((char*)in_path, NULL, &stbuf, &out_item, &stratum_id, &in_item, &tail)) >= 0) {
 		return 0;
 	}
 	return -ENOENT;
@@ -1148,7 +1150,7 @@ static int brp_read(const char *in_path, char *buf, size_t size, off_t offset, s
 	char *tail;
 	char *config_str;
 	struct stat stbuf;
-	int ret;
+	int ret, fd;
 
 	if (strcmp(in_path, "/reparse_config") == 0) {
 		config_str = config_contents();
@@ -1161,12 +1163,12 @@ static int brp_read(const char *in_path, char *buf, size_t size, off_t offset, s
 		return ret;
 	}
 
-	ret = corresponding((char*) in_path, &stbuf, &out_item, &stratum_id, &in_item, &tail);
+	ret = corresponding((char*) in_path, &fd, &stbuf, &out_item, &stratum_id, &in_item, &tail);
 	if (ret < 0) {
 		return ret;
 	}
 
-	return read_filter(ret, out_item->filter, stratum_id, in_item, tail, buf, size, offset);
+	return read_filter(fd, out_item->filter, stratum_id, in_item, tail, buf, size, offset);
 }
 
 /*
@@ -1230,6 +1232,18 @@ int main(int argc, char *argv[])
 	 */
 	if (getuid() != 0){
 		fprintf(stderr, "ERROR: not running as root, aborting.\n");
+		return 1;
+	}
+
+	brp_orig_cwd = open(".", O_RDONLY|O_DIRECTORY);
+	if (brp_orig_cwd < 0) {
+		perror("Failed to open working directory");
+		return 1;
+	}
+
+	brp_orig_root = open("/", O_RDONLY|O_DIRECTORY);
+	if (brp_orig_root < 0) {
+		perror("Failed to open root directory");
 		return 1;
 	}
 

--- a/src/brp/parser.c
+++ b/src/brp/parser.c
@@ -1,0 +1,207 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <string.h>
+
+#include "parser.h"
+
+static inline void skip_until_newline(FILE *f, int *line, int *col) {
+	char *buf = NULL;
+	size_t n = 0;
+	getline(&buf, &n, f);
+	free(buf);
+	(*line)++;
+	*col = 0;
+}
+
+static inline void skip_spaces(FILE *f, int *line, int *col) {
+	int c;
+	while(isspace(c = fgetc(f)) && c != EOF) {
+		if (c == '\n') {
+			(*line)++;
+			*col = 0;
+		} else
+			(*col)++;
+	}
+	if (c != EOF)
+		ungetc(c, f);
+}
+
+struct _buffer {
+	char *buf;
+	size_t sz, len;
+};
+
+static inline void push_char(int c, struct _buffer *buf) {
+	if (buf->len+1 >= buf->sz) {
+		buf->sz = buf->sz ? buf->sz*2 : 64;
+		buf->buf = realloc(buf->buf, buf->sz);
+	}
+	buf->buf[buf->len++] = (char)c;
+}
+
+static inline void init_buf(struct _buffer *buf) {
+	buf->buf = (void *)(buf->sz = buf->len = 0);
+}
+
+static inline char *finalize_buf(struct _buffer *buf) {
+	char *ret = buf->buf;
+	if (!ret)
+		return NULL;
+
+	ret[buf->len] = '\0';
+	init_buf(buf);
+	return ret;
+}
+
+struct section *
+parse_config(const char *file, int *_nsec) {
+	FILE *cfg = fopen(file, "r");
+	struct _buffer buf = {0};
+	struct section *sec_head = NULL, **sec_next = &sec_head, *sec_curr;
+	struct entry **e_next = NULL, *e_curr;
+	struct rhs **rhs_next = NULL, *rhs_curr;
+	int nsec = 0;
+	int line = 1, col = 0;
+	int c;
+	if (!cfg)
+		return NULL;
+
+	enum {
+		LHS,
+		RHS,
+		SECTION,
+		PRELHS,
+		PRERHS
+	} state = PRELHS;
+	do {
+		c = fgetc(cfg);
+		if (c == '\n') {
+			line++;
+			col = 0;
+		} else
+			col++;
+		//fprintf(stderr, "%d, %d: %c\n", line, col, c);
+		if (c == '#') {
+			skip_until_newline(cfg, &line, &col);
+			c = '\n';
+		}
+		if (isspace(c)) {
+			if (state == LHS)
+				goto lhs_end;
+			else if (state == PRELHS || state == PRERHS) {
+				skip_spaces(cfg, &line, &col);
+				continue;
+			}
+		}
+		if (c == EOF) {
+		handle_eof:
+			switch(state) {
+			case PRELHS: case PRERHS:
+				goto end;
+			case RHS:
+				goto rhs_end;
+			case LHS:
+				goto lhs_end;
+			case SECTION:
+				goto err;
+			}
+		}
+		switch(c) {
+		case '\\':
+			c = fgetc(cfg);
+			if (c == EOF)
+				goto handle_eof;
+			if (c == '\n') {
+				line++;
+				col = 0;
+			} else
+				col++;
+			goto plain_char;
+		case '[':
+			// New section
+			if (state != PRELHS)
+				goto plain_char;
+			state = SECTION;
+			break;
+		case ']':
+			if (state != SECTION)
+				goto plain_char;
+			*sec_next = malloc(sizeof(struct section));
+			sec_curr = *sec_next;
+			memset(sec_curr, 0, sizeof(*sec_curr));
+			sec_curr->name_len = buf.len;
+			sec_curr->name = finalize_buf(&buf);
+			sec_next = &sec_curr->next;
+			e_next = &sec_curr->e;
+			skip_spaces(cfg, &line, &col);
+			state = PRELHS;
+			nsec++;
+			break;
+		case ',':
+		case '\n':
+			if (state != RHS)
+				goto plain_char;
+			if (!buf.buf)
+				//Empty rhs, ignore
+				goto rhs_end;
+			*rhs_next = malloc(sizeof(struct rhs));
+			rhs_curr = *rhs_next;
+			rhs_curr->next = NULL;
+			rhs_curr->len = buf.len;
+			rhs_curr->str = finalize_buf(&buf);
+			rhs_next = &rhs_curr->next;
+			e_curr->nrhs++;
+			skip_spaces(cfg, &line, &col);
+		rhs_end:
+			if (c == ',')
+				break;
+			//End of entry
+			state = PRELHS;
+			break;
+		case '=':
+		lhs_end:
+			if (state == PRERHS) {
+				state = RHS;
+				skip_spaces(cfg, &line, &col);
+				break;
+			}
+			if (state != LHS)
+				goto plain_char;
+			*e_next = malloc(sizeof(struct entry));
+			e_curr = *e_next;
+			memset(e_curr, 0, sizeof(*e_curr));
+			e_next = &e_curr->next;
+			e_curr->lhs_len = buf.len;
+			e_curr->lhs = finalize_buf(&buf);
+			sec_curr->nent++;
+			rhs_next = &e_curr->r;
+			skip_spaces(cfg, &line, &col);
+			state = c == '=' ? RHS : PRERHS;
+			break;
+		default:
+		plain_char:
+			if (state == PRELHS) {
+				if (sec_head == NULL)
+					return NULL;
+				state = LHS;
+			} else if (state == PRERHS)
+				state = LHS;
+			if (c == EOF)
+				break;
+			push_char(c, &buf);
+		}
+	} while(c != EOF);
+end:
+	fclose(cfg);
+	*_nsec = nsec;
+	return sec_head;
+err:
+	fclose(cfg);
+	*_nsec = 0;
+	free(buf.buf);
+	free_sections(sec_head);
+
+	fprintf(stderr, "Failed to parse config, line %d, col %d: Unexpected '%c'\n", line, col, c);
+	return NULL;
+}

--- a/src/brp/parser.h
+++ b/src/brp/parser.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <stdlib.h>
+#include <stdio.h>
+
+struct rhs {
+	char *str;
+	size_t len;
+	struct rhs *next;
+};
+struct entry {
+	char *lhs;
+	size_t lhs_len;
+	int nrhs;
+	struct rhs *r;
+	struct entry *next;
+};
+struct section {
+	char *name;
+	size_t name_len;
+	int nent;
+	struct entry *e;
+	struct section *next;
+};
+
+static inline void free_sections(struct section *sec_head) {
+	struct entry *e_curr;
+	struct rhs *rhs_curr;
+	while(sec_head) {
+		free(sec_head->name);
+		e_curr = sec_head->e;
+		while(e_curr) {
+			free(e_curr->lhs);
+			rhs_curr = e_curr->r;
+			while(rhs_curr) {
+				struct rhs *tmp = rhs_curr->next;
+				free(rhs_curr->str);
+				free(rhs_curr);
+				rhs_curr = tmp;
+			}
+
+			struct entry *tmp = e_curr->next;
+			free(e_curr);
+			e_curr = tmp;
+		}
+
+		struct section *tmp = sec_head->next;
+		free(sec_head);
+		sec_head = tmp;
+	}
+}
+static inline void print_sections(struct section *sec_head) {
+	struct entry *e_curr;
+	struct rhs *rhs_curr;
+	while(sec_head) {
+		printf("[%s] (%d)\n", sec_head->name, sec_head->nent);
+		e_curr = sec_head->e;
+		while(e_curr) {
+			printf("%s (%d)", e_curr->lhs, e_curr->nrhs);
+			if (e_curr->r)
+				printf(" = ");
+			else
+				printf("\n");
+			rhs_curr = e_curr->r;
+			while(rhs_curr) {
+				if (rhs_curr->next)
+					printf("%s, ", rhs_curr->str);
+				else
+					printf("%s\n", rhs_curr->str);
+				rhs_curr = rhs_curr->next;
+			}
+			e_curr = e_curr->next;
+		}
+
+		sec_head = sec_head->next;
+	}
+}
+
+struct section *parse_config(const char *, int *);

--- a/src/slash-bedrock/sbin/brn
+++ b/src/slash-bedrock/sbin/brn
@@ -428,6 +428,12 @@ fi
 default_stratum=$(awk '$1 == "default_stratum" {default=$3} END {print ""default""}' /bedrock/etc/brn.conf)
 default_cmd=$(awk '$1 == "default_cmd" {default=$3} END {print ""default""}' /bedrock/etc/brn.conf)
 default_timeout=$(awk 'BEGIN{timeout=-1} $1 == "timeout" {timeout=$3} END {print timeout+0}' /bedrock/etc/brn.conf)
+
+if [ "$default_cmd" = "" ]
+then
+	default_cmd=$(bri -c "$default_stratum" init)
+fi
+
 get_init_choice
 i=$?
 


### PR DESCRIPTION
If default_cmd is unset, then the init configured in strata.conf should be
used.
