### PR TITLE
Fix: invalid TZ value

### DIFF
--- a/src/slash-bedrock/etc/rc.conf
+++ b/src/slash-bedrock/etc/rc.conf
@@ -21,7 +21,7 @@
 #   they may conflict.  Instead, it is recommended to copy the desired Olson
 #   database file to /bedrock/etc/localtime and direct TZ to that.  For
 #   example, copy "/usr/share/zoneinfo/America/New_York" if you are in EST/EDT.
-TZ=/bedrock/etc/localtime
+TZ=:/bedrock/etc/localtime
 
 ## Language
 # Set the POSIX LANG variable to set the language/locale information.


### PR DESCRIPTION
As per the GNU C library ( https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html ) - 
When TZ points to a tzdata file, it should start with a ':' 

If this is not the case, we run into undefined behavior (KDE's Plasma DataEngine will make wrong assumptions about our timezone for example. The culprit is QTimeZone)